### PR TITLE
Core implementation for images

### DIFF
--- a/Haipa.sln.DotSettings
+++ b/Haipa.sln.DotSettings
@@ -1,6 +1,7 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IP/@EntryIndexedValue">IP</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=VM/@EntryIndexedValue">VM</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Cmdlets/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Configurer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Haipa/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Dhcp/@EntryIndexedValue">True</s:Boolean>

--- a/src/Haipa.Messages/Commands/OperationTasks/PrepareVirtualMachineImageCommand.cs
+++ b/src/Haipa.Messages/Commands/OperationTasks/PrepareVirtualMachineImageCommand.cs
@@ -8,7 +8,7 @@ namespace Haipa.Messages.Commands.OperationTasks
     {
         public string AgentName { get; set; }
 
-        public VirtualMachineImageConfig ImageConfig { get; set; }
+        public MachineImageConfig ImageConfig { get; set; }
 
     }
 }

--- a/src/Haipa.Messages/Commands/OperationTasks/PrepareVirtualMachineImageCommand.cs
+++ b/src/Haipa.Messages/Commands/OperationTasks/PrepareVirtualMachineImageCommand.cs
@@ -1,0 +1,14 @@
+﻿using Haipa.Messages.Operations;
+using Haipa.VmConfig;
+
+namespace Haipa.Messages.Commands.OperationTasks
+{
+    [SendMessageTo(MessageRecipient.VMHostAgent)]
+    public class PrepareVirtualMachineImageCommand : OperationTaskCommand, IHostAgentCommand
+    {
+        public string AgentName { get; set; }
+
+        public VirtualMachineImageConfig ImageConfig { get; set; }
+
+    }
+}

--- a/src/Haipa.Modules.Controller/ControllerModule.cs
+++ b/src/Haipa.Modules.Controller/ControllerModule.cs
@@ -15,6 +15,7 @@ using Rebus.Handlers;
 using Rebus.Logging;
 using Rebus.Retry.Simple;
 using Rebus.Routing.TypeBased;
+using Rebus.Sagas.Exclusive;
 using Rebus.Serialization.Json;
 using SimpleInjector;
 using SimpleInjector.Lifestyles;
@@ -61,7 +62,11 @@ namespace Haipa.Modules.Controller
                     x.SetNumberOfWorkers(5);
                 })
                 .Timeouts(t => serviceProvider.GetService<IRebusTimeoutConfigurer>().Configure(t))
-                .Sagas(s => serviceProvider.GetService<IRebusSagasConfigurer>().Configure(s))
+                .Sagas(s =>
+                {
+                    serviceProvider.GetService<IRebusSagasConfigurer>().Configure(s);
+                    s.EnforceExclusiveAccess();
+                })
                 .Subscriptions(s => serviceProvider.GetService<IRebusSubscriptionConfigurer>().Configure(s))
 
                 .Serialization(x => x.UseNewtonsoftJson(new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.None }))

--- a/src/Haipa.Modules.Controller/Operations/Workflows/CreateMachineSaga.cs
+++ b/src/Haipa.Modules.Controller/Operations/Workflows/CreateMachineSaga.cs
@@ -12,7 +12,9 @@ namespace Haipa.Modules.Controller.Operations.Workflows
     [UsedImplicitly]
     internal class CreateMachineSaga : OperationTaskWorkflowSaga<CreateMachineCommand, CreateMachineSagaData>,
         IHandleMessages<OperationTaskStatusEvent<PlaceVirtualMachineCommand>>,
-        IHandleMessages<OperationTaskStatusEvent<ConvergeVirtualMachineCommand>>
+        IHandleMessages<OperationTaskStatusEvent<ConvergeVirtualMachineCommand>>,
+        IHandleMessages<OperationTaskStatusEvent<PrepareVirtualMachineImageCommand>>
+
     {
         private readonly IOperationTaskDispatcher _taskDispatcher;
 
@@ -27,6 +29,7 @@ namespace Haipa.Modules.Controller.Operations.Workflows
 
             config.Correlate<OperationTaskStatusEvent<PlaceVirtualMachineCommand>>(m => m.OperationId, d => d.OperationId);
             config.Correlate<OperationTaskStatusEvent<ConvergeVirtualMachineCommand>>(m => m.OperationId, d => d.OperationId);
+            config.Correlate<OperationTaskStatusEvent<PrepareVirtualMachineImageCommand>>(m => m.OperationId, d => d.OperationId);
 
         }
 
@@ -44,10 +47,14 @@ namespace Haipa.Modules.Controller.Operations.Workflows
         {
             return FailOrRun<PlaceVirtualMachineCommand,PlaceVirtualMachineResult>(message, (r) =>
             {
-                var convergeMessage = new ConvergeVirtualMachineCommand
-                    { Config = Data.Config, AgentName = r.AgentName, OperationId = message.OperationId, TaskId = Guid.NewGuid() };
+                Data.AgentName = r.AgentName;
 
-                return _taskDispatcher.Send(convergeMessage);
+                return _taskDispatcher.Send(new PrepareVirtualMachineImageCommand
+                { ImageConfig = Data.Config.VM.Image, 
+                  AgentName = r.AgentName, 
+                  OperationId = message.OperationId, 
+                  TaskId = Guid.NewGuid()
+                });
             });
 
         }
@@ -59,5 +66,15 @@ namespace Haipa.Modules.Controller.Operations.Workflows
         }
 
 
+        public Task Handle(OperationTaskStatusEvent<PrepareVirtualMachineImageCommand> message)
+        {
+            return FailOrRun(message, () =>
+            {
+                var convergeMessage = new ConvergeVirtualMachineCommand
+                    { Config = Data.Config, AgentName = Data.AgentName, OperationId = message.OperationId, TaskId = Guid.NewGuid() };
+
+                return _taskDispatcher.Send(convergeMessage);
+            });
+        }
     }
 }

--- a/src/Haipa.Modules.Controller/Operations/Workflows/CreateMachineSaga.cs
+++ b/src/Haipa.Modules.Controller/Operations/Workflows/CreateMachineSaga.cs
@@ -50,7 +50,7 @@ namespace Haipa.Modules.Controller.Operations.Workflows
                 Data.AgentName = r.AgentName;
 
                 return _taskDispatcher.Send(new PrepareVirtualMachineImageCommand
-                { ImageConfig = Data.Config.VM.Image, 
+                { ImageConfig = Data.Config.Image, 
                   AgentName = r.AgentName, 
                   OperationId = message.OperationId, 
                   TaskId = Guid.NewGuid()

--- a/src/Haipa.Modules.Controller/Operations/Workflows/CreateMachineSagaData.cs
+++ b/src/Haipa.Modules.Controller/Operations/Workflows/CreateMachineSagaData.cs
@@ -5,5 +5,6 @@ namespace Haipa.Modules.Controller.Operations.Workflows
     public class CreateMachineSagaData : TaskWorkflowSagaData
     {
         public MachineConfig Config { get; set; }
+
     }
 }

--- a/src/Haipa.Modules.Controller/Operations/Workflows/CreateMachineSagaData.cs
+++ b/src/Haipa.Modules.Controller/Operations/Workflows/CreateMachineSagaData.cs
@@ -5,6 +5,6 @@ namespace Haipa.Modules.Controller.Operations.Workflows
     public class CreateMachineSagaData : TaskWorkflowSagaData
     {
         public MachineConfig Config { get; set; }
-
+        public string AgentName { get; set; }
     }
 }

--- a/src/Haipa.Modules.Controller/Operations/Workflows/PlaceVirtualMachineSaga.cs
+++ b/src/Haipa.Modules.Controller/Operations/Workflows/PlaceVirtualMachineSaga.cs
@@ -53,9 +53,12 @@ namespace Haipa.Modules.Controller.Operations.Workflows
 
         public Task Handle(PlacementVerificationCompletedEvent message)
         {
-            return !message.Confirmed ? 
-                    CalculatePlacementAndRequestVerification() : 
-                    Complete(new PlaceVirtualMachineResult { AgentName = message.AgentName });
+            // This is not implemented fully - in case not confirmed some state has to be changed too, because
+            // otherwise calculation most likely will choose same agent again resulting in a loop.
+            // Currently this can not happen, as placement will always be confirmed by agent.
+            return message.Confirmed ? 
+                    Complete(new PlaceVirtualMachineResult { AgentName = message.AgentName }) : 
+                    CalculatePlacementAndRequestVerification();
         }
     }
 }

--- a/src/Haipa.Modules.VmHostAgent/ConvergeVirtualMachineCommandHandler.cs
+++ b/src/Haipa.Modules.VmHostAgent/ConvergeVirtualMachineCommandHandler.cs
@@ -167,14 +167,14 @@ namespace Haipa.Modules.VmHostAgent
 
         private static Task<Either<PowershellFailure, (TypedPsObject<VirtualMachineInfo> vmInfo, Option<ImageVirtualMachineInfo> imageVM)>> EnsureCreated(Option<TypedPsObject<VirtualMachineInfo>> vmInfo, MachineConfig config, HostSettings hostSettings, VMStorageSettings storageSettings, IPowershellEngine engine)
         {
-            if (!string.IsNullOrWhiteSpace(config.VM.Image.Id))
+            if (!string.IsNullOrWhiteSpace(config.Image.Name))
             {
                 return vmInfo.MatchAsync(
                     None: () =>
                         storageSettings.StorageIdentifier.ToEither(new PowershellFailure { Message = "Unknown storage identifier, cannot create new virtual machine" })
                             .BindAsync(storageIdentifier => Converge.ImportVirtualMachine(engine, hostSettings, config.Name, storageIdentifier,
                                 storageSettings.VMPath,
-                                config.VM.Image)),
+                                config.Image)),
                     Some: s => (s, Option<ImageVirtualMachineInfo>.None)
                 );
 
@@ -185,7 +185,7 @@ namespace Haipa.Modules.VmHostAgent
                     (storageSettings.StorageIdentifier.ToEither(new PowershellFailure{Message = "Unknown storage identifier, cannot create new virtual machine"})
                         .BindAsync(storageIdentifier => Converge.CreateVirtualMachine(engine, config.Name, storageIdentifier,
                             storageSettings.VMPath,
-                            config.VM.Memory.Startup)).MapAsync(r => (r, Option<ImageVirtualMachineInfo>.None))),                            
+                            config.VM.Memory.Startup.GetValueOrDefault(0))).MapAsync(r => (r, Option<ImageVirtualMachineInfo>.None))),                            
                 Some: s => (s, Option<ImageVirtualMachineInfo>.None)
             );
 
@@ -259,9 +259,9 @@ namespace Haipa.Modules.VmHostAgent
                 var metadataIndex = notes.IndexOf("Haipa metadata id: ", StringComparison.InvariantCultureIgnoreCase);
                 if (metadataIndex != -1)
                 {
-                    var metadataEnd = metadataIndex + 32;
-                    if (metadataEnd < notes.Length)
-                        metadataId = notes.Substring(metadataIndex, 32);
+                    var metadataEnd = metadataIndex + "Haipa metadata id: ".Length + 36;
+                    if (metadataEnd <= notes.Length)
+                        metadataId = notes.Substring(metadataIndex + "Haipa metadata id: ".Length, 36);
 
                 }
             }
@@ -286,7 +286,7 @@ namespace Haipa.Modules.VmHostAgent
                 };
 
                 if (imageInfo.IsSome)
-                    metadata.ImageInfo = imageInfo.ValueUnsafe();
+                    metadata.ImageConfig = imageInfo.ValueUnsafe().ToVmConfig();
 
                 var metadataJson = JsonConvert.SerializeObject(metadata);
                 File.WriteAllText($"{metadata.Id}.hmeta", metadataJson);
@@ -300,12 +300,13 @@ namespace Haipa.Modules.VmHostAgent
         }
     }
 
+    
 
-    public sealed class HaipaMetadata : Record<HaipaMetadata>
+    public sealed class HaipaMetadata
     {
         public Guid Id { get; set; }
         public Guid VMId { get; set; }
-        [CanBeNull] public ImageVirtualMachineInfo ImageInfo { get; set; }
+        [CanBeNull] public VirtualMachineConfig ImageConfig { get; set; }
         [CanBeNull] public VirtualMachineProvisioningConfig ProvisioningConfig { get; set; }
 
     }

--- a/src/Haipa.Modules.VmHostAgent/HostSettingsBuilder.cs
+++ b/src/Haipa.Modules.VmHostAgent/HostSettingsBuilder.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.IO;
+using System.Management;
+using Haipa.VmManagement.Data;
+
+namespace Haipa.Modules.VmHostAgent
+{
+    internal class HostSettingsBuilder
+    {
+        public static HostSettings GetHostSettings()
+        {
+
+            var scope = new ManagementScope(@"\\.\root\virtualization\v2");
+            var query = new ObjectQuery("select DefaultExternalDataRoot,DefaultVirtualHardDiskPath from Msvm_VirtualSystemManagementServiceSettingData");
+
+
+            var searcher = new ManagementObjectSearcher (scope, query );
+            var settingsCollection = searcher.Get ( );
+            
+            foreach (var hostSettings in settingsCollection)
+            {
+                return new HostSettings
+                {
+                    DefaultVirtualHardDiskPath = Path.Combine(hostSettings.GetPropertyValue("DefaultVirtualHardDiskPath")?.ToString(), "Haipa"),
+                    DefaultDataPath = Path.Combine(hostSettings.GetPropertyValue("DefaultExternalDataRoot")?.ToString(), "Haipa")
+                };
+            }
+
+            throw new Exception("failed to query for hyper-v host settings");
+
+        }
+    }
+}

--- a/src/Haipa.Modules.VmHostAgent/PrepareVirtualMachineImageCommandHandler.cs
+++ b/src/Haipa.Modules.VmHostAgent/PrepareVirtualMachineImageCommandHandler.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Haipa.Messages;
+using Haipa.Messages.Commands.OperationTasks;
+using Haipa.Messages.Operations;
+using Haipa.VmConfig;
+using JetBrains.Annotations;
+using Rebus.Bus;
+using Rebus.Handlers;
+
+namespace Haipa.Modules.VmHostAgent
+{
+    [UsedImplicitly]
+    public class PrepareVirtualMachineImageCommandHandler : IHandleMessages<AcceptedOperationTask<PrepareVirtualMachineImageCommand>>
+    {
+        private readonly IBus _bus;
+
+        public PrepareVirtualMachineImageCommandHandler(IBus bus)
+        {
+            _bus = bus;
+        }
+
+        public Task Handle(AcceptedOperationTask<PrepareVirtualMachineImageCommand> message)
+        {
+            try
+            {
+
+                var hostSettings = HostSettingsBuilder.GetHostSettings();
+                var imageRootPath = Path.Combine(hostSettings.DefaultVirtualHardDiskPath, "Images");
+
+                if (!Directory.Exists(imageRootPath))
+                    Directory.CreateDirectory(imageRootPath);
+
+                var imagePath = Path.Combine(imageRootPath,
+                    $"{message.Command.ImageConfig.Id}\\{message.Command.ImageConfig.Version}");
+
+                if (Directory.Exists(imagePath))
+                {
+                    return _bus.Publish(
+                        OperationTaskStatusEvent.Completed(message.Command.OperationId, message.Command.TaskId));
+                }
+
+                if (message.Command.ImageConfig.Source == VirtualMachineImageSource.Local)
+                    throw new Exception("Image not found on local source.");
+
+                return Task.CompletedTask;
+            }
+            catch (Exception ex)
+            {
+                return _bus.Publish(OperationTaskStatusEvent.Failed(message.Command.OperationId,
+                    message.Command.TaskId,
+                    new ErrorData { ErrorMessage = ex.Message }));
+
+            }
+
+        }
+    }
+}

--- a/src/Haipa.Modules.VmHostAgent/PrepareVirtualMachineImageCommandHandler.cs
+++ b/src/Haipa.Modules.VmHostAgent/PrepareVirtualMachineImageCommandHandler.cs
@@ -33,7 +33,7 @@ namespace Haipa.Modules.VmHostAgent
                     Directory.CreateDirectory(imageRootPath);
 
                 var imagePath = Path.Combine(imageRootPath,
-                    $"{message.Command.ImageConfig.Id}\\{message.Command.ImageConfig.Version}");
+                    $"{message.Command.ImageConfig.Name}\\{message.Command.ImageConfig.Tag}");
 
                 if (Directory.Exists(imagePath))
                 {
@@ -41,7 +41,7 @@ namespace Haipa.Modules.VmHostAgent
                         OperationTaskStatusEvent.Completed(message.Command.OperationId, message.Command.TaskId));
                 }
 
-                if (message.Command.ImageConfig.Source == VirtualMachineImageSource.Local)
+                if (message.Command.ImageConfig.Source == MachineImageSource.Local)
                     throw new Exception("Image not found on local source.");
 
                 return Task.CompletedTask;

--- a/src/Haipa.Modules.VmHostAgent/PrepareVirtualMachineImageCommandHandler.cs
+++ b/src/Haipa.Modules.VmHostAgent/PrepareVirtualMachineImageCommandHandler.cs
@@ -25,6 +25,11 @@ namespace Haipa.Modules.VmHostAgent
         {
             try
             {
+                if (message.Command.ImageConfig == null)
+                {
+                    return _bus.Publish(
+                        OperationTaskStatusEvent.Completed(message.Command.OperationId, message.Command.TaskId));
+                }
 
                 var hostSettings = HostSettingsBuilder.GetHostSettings();
                 var imageRootPath = Path.Combine(hostSettings.DefaultVirtualHardDiskPath, "Images");

--- a/src/Haipa.Modules.VmHostAgent/VerifyPlacementCalculationCommandHandler.cs
+++ b/src/Haipa.Modules.VmHostAgent/VerifyPlacementCalculationCommandHandler.cs
@@ -2,11 +2,13 @@
 using System.Threading.Tasks;
 using Haipa.Messages.Events;
 using Haipa.Messages.Operations;
+using JetBrains.Annotations;
 using Rebus.Bus;
 using Rebus.Handlers;
 
 namespace Haipa.Modules.VmHostAgent
 {
+    [UsedImplicitly]
     public class VerifyPlacementCalculationCommandHandler : IHandleMessages<VerifyPlacementCalculationCommand>
     {
         private readonly IBus _bus;

--- a/src/Haipa.StateDb/Model/Machine.cs
+++ b/src/Haipa.StateDb/Model/Machine.cs
@@ -18,4 +18,6 @@ namespace Haipa.StateDb.Model
         public VirtualMachine VM { get; set; }
         public virtual List<MachineNetwork> Networks { get; set; }
     }
+
+
 }

--- a/src/Haipa.VmConfig.Primitives/VirtualMachineConfig.cs
+++ b/src/Haipa.VmConfig.Primitives/VirtualMachineConfig.cs
@@ -7,16 +7,16 @@ namespace Haipa.VmConfig
 {
     public class VirtualMachineCpuConfig
     {
-        public int Count { get; set; }
+        public int? Count { get; set; }
     }
 
     public class VirtualMachineMemoryConfig
     {
-        public int Startup { get; set; }
+        public int? Startup { get; set; }
 
-        public int Minimum { get; set; }
+        public int? Minimum { get; set; }
 
-        public int Maximum { get; set; }
+        public int? Maximum { get; set; }
     }
 
     public class VirtualMachineDriveConfig
@@ -75,8 +75,6 @@ namespace Haipa.VmConfig
         public string Slug { get; set; }
         public string DataStore { get; set; }
 
-        public VirtualMachineImageConfig Image { get; set; }
-
         public VirtualMachineCpuConfig Cpu { get; set; }
 
         public VirtualMachineMemoryConfig Memory { get; set; }
@@ -87,17 +85,17 @@ namespace Haipa.VmConfig
 
     }
 
-    public class VirtualMachineImageConfig
+    public class MachineImageConfig
     {
-        public VirtualMachineImageSource Source { get; set; }
-        public string Id { get; set; }
-        public string Version { get; set; }
+        public MachineImageSource Source { get; set; }
+        public string Name { get; set; }
+        public string Tag { get; set; }
     }
 
-    public enum VirtualMachineImageSource
+    public enum MachineImageSource
     {
         Local,
-        Vagrant
+        VagrantVM
     }
 
     public class MachineConfig
@@ -105,6 +103,8 @@ namespace Haipa.VmConfig
         public string Name { get; set; }
         public string Environment { get; set; }
         public string Project { get; set; }
+
+        public MachineImageConfig Image { get; set; }
 
         public VirtualMachineConfig VM { get; set; }
 

--- a/src/Haipa.VmConfig.Primitives/VirtualMachineConfig.cs
+++ b/src/Haipa.VmConfig.Primitives/VirtualMachineConfig.cs
@@ -75,6 +75,8 @@ namespace Haipa.VmConfig
         public string Slug { get; set; }
         public string DataStore { get; set; }
 
+        public VirtualMachineImageConfig Image { get; set; }
+
         public VirtualMachineCpuConfig Cpu { get; set; }
 
         public VirtualMachineMemoryConfig Memory { get; set; }
@@ -83,6 +85,19 @@ namespace Haipa.VmConfig
 
         public List<VirtualMachineNetworkAdapterConfig> NetworkAdapters { get; set; }
 
+    }
+
+    public class VirtualMachineImageConfig
+    {
+        public VirtualMachineImageSource Source { get; set; }
+        public string Id { get; set; }
+        public string Version { get; set; }
+    }
+
+    public enum VirtualMachineImageSource
+    {
+        Local,
+        Vagrant
     }
 
     public class MachineConfig

--- a/src/Haipa.VmManagement/Converge.cs
+++ b/src/Haipa.VmManagement/Converge.cs
@@ -4,9 +4,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Security.Cryptography.X509Certificates;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using AutoMapper;
 using Haipa.CloudInit.ConfigDrive.Generator;
@@ -17,6 +15,7 @@ using Haipa.VmConfig;
 using Haipa.VmManagement.Data;
 using LanguageExt;
 using LanguageExt.UnsafeValueAccess;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using static LanguageExt.Prelude;
 
@@ -41,8 +40,8 @@ namespace Haipa.VmManagement
                 machineConfig.Name = "haipa-machine";
             }
 
-            if(machineConfig.VM.Image == null)
-                machineConfig.VM.Image = new VirtualMachineImageConfig();
+            if(machineConfig.Image == null)
+                machineConfig.Image = new MachineImageConfig();
 
 
             if (machineConfig.VM.Cpu == null)
@@ -92,41 +91,77 @@ namespace Haipa.VmManagement
         }
 
 
-        public static Task<Either<PowershellFailure, MachineConfig>> MergeConfigAndImageSettings(Option<ImageVirtualMachineInfo> imageVmInfo, MachineConfig originalConfig, IPowershellEngine engine)
+        public static Task<Either<PowershellFailure, MachineConfig>> MergeConfigAndImageSettings(Option<VirtualMachineConfig> optionalImageConfig, MachineConfig machineConfig, IPowershellEngine engine)
         {
 
-            if (string.IsNullOrWhiteSpace(originalConfig.VM.Image.Id))
-                return RightAsync<PowershellFailure, MachineConfig>(originalConfig).ToEither(); ;
+            if (string.IsNullOrWhiteSpace(machineConfig.Image.Name))
+                return RightAsync<PowershellFailure, MachineConfig>(machineConfig).ToEither(); ;
 
+            //copy machine config to a new object
+            var mapper = new Mapper(new MapperConfiguration(c =>
+            {
+                c.CreateMap<MachineConfig, MachineConfig>();
+                c.CreateMap<VirtualMachineConfig, VirtualMachineConfig>();
+                c.CreateMap<VirtualMachineCpuConfig, VirtualMachineCpuConfig>();
+                c.CreateMap<VirtualMachineMemoryConfig, VirtualMachineMemoryConfig>();
+                c.CreateMap<VirtualMachineNetworkAdapterConfig, VirtualMachineNetworkAdapterConfig>();
+                c.CreateMap<VirtualMachineDriveConfig, VirtualMachineDriveConfig>();
 
-            var mapper = new Mapper(new MapperConfiguration(c => { }));
-            var newConfig = mapper.DefaultContext.Mapper.Map<MachineConfig>(originalConfig);
+            }));
+            var newConfig = mapper.DefaultContext.Mapper.Map<MachineConfig, MachineConfig>(machineConfig);
+                
+            return optionalImageConfig.HeadOrLeft(new PowershellFailure { Message = "Missing image configuration info" })
+                .Map(imageConfig =>
+                {
+                    //initialize machine config with image settings
+                    newConfig.VM = mapper.DefaultContext.Mapper.Map<VirtualMachineConfig, VirtualMachineConfig>(imageConfig);
 
-            return imageVmInfo.HeadOrLeft(new PowershellFailure {Message = "Missing image configuration info"})
-                .Map(config => config.HardDrives.ToSeq()
-
-                    .Map(vhdInfo => new VirtualMachineDriveConfig
-                    {
-                        Name = Path.GetFileNameWithoutExtension(vhdInfo.Path),
-                        Type = VirtualMachineDriveType.VHD,
-                        Size = (int) Math.Ceiling(vhdInfo.Size / 1024d / 1024 / 1024)
-                    })
-                    .Iter(ihd =>
-                        {
-                            if (newConfig.VM.Drives.Any(x => x.Name == ihd.Name)) return;
-
-                            var origHd = originalConfig.VM.Drives.FirstOrDefault(x => x.Name == ihd.Name);
-
-                            if (origHd != null)
+                    //merge drive settings configured both on image and vm config
+                    newConfig.VM.Drives.ToSeq()
+                        .Iter(ihd =>
                             {
-                                ihd.Size = origHd.Size;
-                                ihd.DataStore = origHd.DataStore;
-                                ihd.ShareSlug = origHd.ShareSlug;
-                            }
+                                var vmHdConfig = machineConfig.VM.Drives.FirstOrDefault(x => x.Name == ihd.Name);
 
-                            newConfig.VM.Drives.Add(ihd);
-                        }
-                    )).Map(u => newConfig).AsTask();
+                                if (vmHdConfig == null) return;
+
+                                if(vmHdConfig.Size!=0) ihd.Size = vmHdConfig.Size;
+                                if(!string.IsNullOrWhiteSpace(vmHdConfig.DataStore)) ihd.DataStore = vmHdConfig.DataStore;
+                                if(!string.IsNullOrWhiteSpace(vmHdConfig.ShareSlug))  ihd.ShareSlug = vmHdConfig.ShareSlug;
+                            }
+                        );
+
+                    //add drives configured only on vm
+                    var imageDriveNames = newConfig.VM.Drives.Select(x => x.Name);
+                    newConfig.VM.Drives.AddRange(machineConfig.VM.Drives.Where(vmHd => !imageDriveNames.Any(x=> string.Equals(x, vmHd.Name, StringComparison.InvariantCultureIgnoreCase))  ));
+
+                    //merge network adapter settings configured both on image and vm config
+                    newConfig.VM.NetworkAdapters.ToSeq()
+                        .Iter(iad =>
+                            {
+                                var vmAdapterConfig = machineConfig.VM.NetworkAdapters.FirstOrDefault(x => x.Name == iad.Name);
+
+                                if (vmAdapterConfig == null) return;
+                                if (!string.IsNullOrWhiteSpace(vmAdapterConfig.MacAddress)) iad.MacAddress = vmAdapterConfig.MacAddress;
+                                if (!string.IsNullOrWhiteSpace(vmAdapterConfig.SwitchName)) iad.SwitchName = vmAdapterConfig.SwitchName;
+                            }
+                        );
+
+                    //add network adapters configured only on vm
+                    var imageAdapterNames = newConfig.VM.NetworkAdapters.Select(x => x.Name);
+                    newConfig.VM.NetworkAdapters.AddRange(machineConfig.VM.NetworkAdapters.Where(vmHd => !imageAdapterNames.Any(x => string.Equals(x, vmHd.Name, StringComparison.InvariantCultureIgnoreCase))));
+
+                    //merge other settings
+                    if (!string.IsNullOrWhiteSpace(machineConfig.VM.DataStore)) newConfig.VM.DataStore = machineConfig.VM.DataStore;
+                    if (!string.IsNullOrWhiteSpace(machineConfig.VM.Slug)) newConfig.VM.DataStore = machineConfig.VM.Slug;
+
+                    if (machineConfig.VM.Cpu.Count.GetValueOrDefault(0) != 0) newConfig.VM.Cpu.Count = machineConfig.VM.Cpu.Count;
+                    if (machineConfig.VM.Memory.Maximum.HasValue) newConfig.VM.Memory.Maximum = machineConfig.VM.Memory.Maximum;
+                    if (machineConfig.VM.Memory.Minimum.HasValue) newConfig.VM.Memory.Minimum = machineConfig.VM.Memory.Minimum;
+                    if (machineConfig.VM.Memory.Startup.GetValueOrDefault(0) != 0) newConfig.VM.Memory.Startup = machineConfig.VM.Memory.Startup;
+
+
+                    return Unit.Default.AsTask();
+                }).Map(u => newConfig).AsTask();
 
 
         }
@@ -627,18 +662,12 @@ namespace Haipa.VmManagement
             string vmName,
             string storageIdentifier,
             string vmPath,
-            VirtualMachineImageConfig imageConfig)
+            MachineImageConfig imageConfig)
         {
-
-            var mapper = new Mapper(new MapperConfiguration(c =>
-            {
-                c.CreateMap<HardDiskDriveInfo,ImageHardDiskDriveInfo>(MemberList.None);
-            }));
-
 
             var imageRootPath = Path.Combine(hostSettings.DefaultVirtualHardDiskPath, "Images");
             var imagePath = Path.Combine(imageRootPath,
-                $"{imageConfig.Id}\\{imageConfig.Version}\\");
+                $"{imageConfig.Name}\\{imageConfig.Tag}\\");
 
             var configRootPath = Path.Combine(imagePath, "Virtual Machines");
 
@@ -677,11 +706,32 @@ namespace Haipa.VmManagement
                 .BindAsync(realizedVM => (
                         from _ in RenameDisksToConvention(engine, realizedVM).ToAsync()
                         from vm in realizedVM.Reload(engine).ToAsync()
-                        let imageVm = mapper.DefaultContext.Mapper.Map<ImageVirtualMachineInfo>(vm.Value)
+                        from imageVm in CreateImageVMInfo(vm ,engine).ToAsync()
                         select (vm, Option<ImageVirtualMachineInfo>.Some(imageVm))).ToEither());
 
 
             return vmInfo;
+        }
+
+
+        private static readonly Mapper ImageInfoMapper = new Mapper(new MapperConfiguration(c =>
+        {
+            c.CreateMap<HardDiskDriveInfo, ImageHardDiskDriveInfo>(MemberList.None);
+        }));
+
+        private static Task<Either<PowershellFailure, ImageVirtualMachineInfo>> CreateImageVMInfo(TypedPsObject<VirtualMachineInfo> vmInfo, IPowershellEngine engine)
+        {
+            var imageInfo = ImageInfoMapper.DefaultContext.Mapper.Map<ImageVirtualMachineInfo>(vmInfo.Value);
+
+            return imageInfo.HardDrives.ToSeq().MapToEitherAsync(hd =>
+                    (from optionalDrive in Storage.GetVhdInfo(hd.Path, engine).ToAsync()
+                        from drive in optionalDrive.ToEither(new PowershellFailure {Message = "Failed to find realized image disk"})
+                            .ToAsync()
+                        let _ = drive.Apply(d => hd.Size = d.Value.Size)
+                        select hd).ToEither())
+
+                .MapT(hd => imageInfo);
+
         }
 
 

--- a/src/Haipa.VmManagement/Data/HardDiskDriveInfo.cs
+++ b/src/Haipa.VmManagement/Data/HardDiskDriveInfo.cs
@@ -14,7 +14,7 @@
 
         //public CacheAttributes? WriteHardeningMethod { get; set; }
 
-        internal AttachedDiskType AttachedDiskType { get; set; }
+        //public AttachedDiskType AttachedDiskType { get; set; }
 
     }
 }

--- a/src/Haipa.VmManagement/Data/IVirtualMachineCoreInfo.cs
+++ b/src/Haipa.VmManagement/Data/IVirtualMachineCoreInfo.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Haipa.VmManagement.Data
+{
+    public interface IVirtualMachineCoreInfo
+    {
+        Guid Id { get; }
+        string Name { get; }
+        DvdDriveInfo[] DVDDrives { get; }
+        HardDiskDriveInfo[] HardDrives { get; }
+        int Generation { get; }
+        bool IsClustered { get; }
+        string Path { get; }
+    }
+}

--- a/src/Haipa.VmManagement/Data/ImageVMNetworkAdapter.cs
+++ b/src/Haipa.VmManagement/Data/ImageVMNetworkAdapter.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Haipa.VmManagement.Data
+{
+    public class ImageVMNetworkAdapter : VirtualMachineDeviceInfo
+    {
+        public bool IsLegacy { get; private set; }
+
+        public string SwitchName { get; set; }
+
+        public string AdapterId { get; private set; }
+
+        public OnOffState MacAddressSpoofing { get; private set; }
+        
+
+        public OnOffState AllowTeaming { get; private set; }
+
+
+    }
+}

--- a/src/Haipa.VmManagement/Data/ImageVMNetworkAdapterInfo.cs
+++ b/src/Haipa.VmManagement/Data/ImageVMNetworkAdapterInfo.cs
@@ -1,28 +1,14 @@
-﻿using System;
-
-namespace Haipa.VmManagement.Data
+﻿namespace Haipa.VmManagement.Data
 {
-    public class PlannedVMNetworkAdapter : VirtualMachineDeviceInfo
+    public sealed class ImageVMNetworkAdapterInfo : VirtualMachineDeviceInfo
     {
         public string MacAddress { get; private set; }
 
         public bool DynamicMacAddressEnabled { get; private set; }
 
-    }
-
-    public class VMNetworkAdapter : VirtualMachineDeviceInfo
-    {
-
-        public bool ClusterMonitored { get; private set; }
-
-        public string MacAddress { get; private set; }
-
-        public bool DynamicMacAddressEnabled { get; private set; }
-
-        //public bool AllowPacketDirect { get; private set; }
+        public bool AllowPacketDirect { get; private set; }
 
         public bool IsLegacy { get; private set; }
-        public string[] IPAddresses { get; private set; }
 
         //public OnOffState DeviceNaming { get; private set; }
 
@@ -49,27 +35,13 @@ namespace Haipa.VmManagement.Data
 
         //public string PoolName { get; private set; }
 
-        public bool Connected { get; private set; }
 
         //public string TestReplicaPoolName { get; private set; }
 
         //public string TestReplicaSwitchName { get; private set; }
 
-        public string SwitchName { get; private set; }
-
-        public string AdapterId { get; private set; }
-
         //public string[] StatusDescription { get; private set; }
 
-
-        //public VMNetworkAdapterOperationalStatus[] Status { get; private set; }
-
-
-        //public bool IsManagementOs { get; private set; }
-
-        //public bool IsExternalAdapter { get; private set; }
-
-        public Guid? SwitchId { get; private set; }
 
 
         public VMNetworkAdapterAclSetting[] AclList { get; private set; }
@@ -87,7 +59,6 @@ namespace Haipa.VmManagement.Data
 
 
         public VMNetworkAdapterBandwidthSetting BandwidthSetting { get; private set; }
-
 
 
         public VMNetworkAdapterIsolationMode CurrentIsolationMode { get; private set; }
@@ -174,15 +145,6 @@ namespace Haipa.VmManagement.Data
 
         //public VrssVmbusChannelAffinityPolicyType VrssVmbusChannelAffinityPolicyRequested { get; private set; }
 
-        //public int VmqUsage { get; private set; }
-
-
-        //public uint IPsecOffloadSAUsage { get; private set; }
-
-
-        public bool VFDataPathActive { get; private set; }
-
-        public uint BandwidthPercentage { get; private set; }
 
     }
 }

--- a/src/Haipa.VmManagement/Data/ImageVirtualMachineInfo.cs
+++ b/src/Haipa.VmManagement/Data/ImageVirtualMachineInfo.cs
@@ -12,7 +12,7 @@ namespace Haipa.VmManagement.Data
 
         public ImageHardDiskDriveInfo[] HardDrives { get; set; }
 
-        public VMNetworkAdapter[] NetworkAdapters { get;  set; }
+        public ImageVMNetworkAdapter[] NetworkAdapters { get;  set; }
 
         public int Generation { get; set; }
 
@@ -35,13 +35,7 @@ namespace Haipa.VmManagement.Data
         public ulong? MaximumIOPS { get; set; }
 
         public ulong? MinimumIOPS { get; set; }
-
-        //public Guid? QoSPolicyID { get; set; }
-
-        public bool? SupportPersistentReservations { get; set; }
-
-        //public CacheAttributes? WriteHardeningMethod { get; set; }
-
+        
         public AttachedDiskType AttachedDiskType { get; set; }
 
         public long Size { get; set;  }

--- a/src/Haipa.VmManagement/Data/ImageVirtualMachineInfo.cs
+++ b/src/Haipa.VmManagement/Data/ImageVirtualMachineInfo.cs
@@ -1,0 +1,41 @@
+﻿using LanguageExt;
+
+namespace Haipa.VmManagement.Data
+{
+    public sealed class ImageVirtualMachineInfo : Record<ImageVirtualMachineInfo>
+    {
+        public DvdDriveInfo[] DVDDrives { get; private set; }
+
+        public VMFibreChannelHbaInfo[] FibreChannelHostBusAdapters { get; private set; }
+
+        public VMFloppyDiskDriveInfo FloppyDrive { get; private set; }
+
+        public ImageHardDiskDriveInfo[] HardDrives { get; private set; }
+
+        public VMNetworkAdapter[] NetworkAdapters { get; private set; }
+
+        public int Generation { get; private set; }
+
+    }
+
+
+    public sealed class ImageHardDiskDriveInfo : DriveInfo
+    {
+        public int? DiskNumber { get; set; }
+
+        public ulong? MaximumIOPS { get; set; }
+
+        public ulong? MinimumIOPS { get; set; }
+
+        //public Guid? QoSPolicyID { get; set; }
+
+        public bool? SupportPersistentReservations { get; set; }
+
+        //public CacheAttributes? WriteHardeningMethod { get; set; }
+
+        public AttachedDiskType AttachedDiskType { get; set; }
+
+        public long Size { get; set;  }
+
+    }
+}

--- a/src/Haipa.VmManagement/Data/ImageVirtualMachineInfo.cs
+++ b/src/Haipa.VmManagement/Data/ImageVirtualMachineInfo.cs
@@ -2,19 +2,28 @@
 
 namespace Haipa.VmManagement.Data
 {
-    public sealed class ImageVirtualMachineInfo : Record<ImageVirtualMachineInfo>
+    public sealed class ImageVirtualMachineInfo
     {
-        public DvdDriveInfo[] DVDDrives { get; private set; }
+        public DvdDriveInfo[] DVDDrives { get; set; }
 
-        public VMFibreChannelHbaInfo[] FibreChannelHostBusAdapters { get; private set; }
+        public VMFibreChannelHbaInfo[] FibreChannelHostBusAdapters { get; set; }
 
-        public VMFloppyDiskDriveInfo FloppyDrive { get; private set; }
+        public VMFloppyDiskDriveInfo FloppyDrive { get; set; }
 
-        public ImageHardDiskDriveInfo[] HardDrives { get; private set; }
+        public ImageHardDiskDriveInfo[] HardDrives { get; set; }
 
-        public VMNetworkAdapter[] NetworkAdapters { get; private set; }
+        public VMNetworkAdapter[] NetworkAdapters { get;  set; }
 
-        public int Generation { get; private set; }
+        public int Generation { get; set; }
+
+        public long ProcessorCount { get; set; }
+
+        public long MemoryMaximum { get; set; }
+
+        public long MemoryMinimum { get; set; }
+
+        public long MemoryStartup { get; set; }
+
 
     }
 

--- a/src/Haipa.VmManagement/Data/VMNetworkAdapter.cs
+++ b/src/Haipa.VmManagement/Data/VMNetworkAdapter.cs
@@ -10,6 +10,7 @@ namespace Haipa.VmManagement.Data
 
     }
 
+
     public class VMNetworkAdapter : VirtualMachineDeviceInfo
     {
 

--- a/src/Haipa.VmManagement/Data/VirtualMachineInfo.cs
+++ b/src/Haipa.VmManagement/Data/VirtualMachineInfo.cs
@@ -9,7 +9,7 @@ using LanguageExt;
 
 namespace Haipa.VmManagement.Data
 {
-    public sealed class VirtualMachineInfo : Record<VirtualMachineInfo>
+    public sealed class VirtualMachineInfo : Record<VirtualMachineInfo>, IVirtualMachineCoreInfo
     {
 
         public DateTime CreationTime { get; private set; }
@@ -223,6 +223,48 @@ namespace Haipa.VmManagement.Data
         //public OnOffState? LockOnDisconnect { get; private set; }
 
 
+
+    }
+
+    public sealed class PlannedVirtualMachineInfo : Record<VirtualMachineInfo>, IVirtualMachineCoreInfo
+    {
+        public Guid Id { get; private set; }
+
+        public string Name { get; private set; }
+
+        public string ConfigurationLocation { get; private set; }
+
+        public bool SmartPagingFileInUse { get; private set; }
+
+        public string SmartPagingFilePath { get; private set; }
+
+        public string SnapshotFileLocation { get; private set; }
+
+
+        public DvdDriveInfo[] DVDDrives { get; private set; }
+        
+        public VMFibreChannelHbaInfo[] FibreChannelHostBusAdapters { get; private set; }
+
+        public VMFloppyDiskDriveInfo FloppyDrive { get; private set; }
+
+        public HardDiskDriveInfo[] HardDrives { get; private set; }
+
+        public PlannedVMNetworkAdapter[] NetworkAdapters { get; private set; }
+
+        public int Generation { get; private set; }
+
+        public bool IsClustered { get; private set; }
+
+        public string Path { get; private set; }
+
+        public string Version { get; private set; }
+
+    }
+
+
+    public class VMCompatibilityReportInfo : Record<VMCompatibilityReportInfo>
+    {
+        public PlannedVirtualMachineInfo VM { get; private set; }
 
     }
 }

--- a/src/Haipa.VmManagement/ImageVirtualMachineInfoExtensions.cs
+++ b/src/Haipa.VmManagement/ImageVirtualMachineInfoExtensions.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Haipa.VmConfig;
+using Haipa.VmManagement.Data;
+
+namespace Haipa.Modules.VmHostAgent
+{
+    public static class ImageVirtualMachineInfoExtensions
+    {
+        public static VirtualMachineConfig ToVmConfig(this ImageVirtualMachineInfo imageInfo)
+        {
+            return new VirtualMachineConfig
+            {
+                Cpu = new VirtualMachineCpuConfig
+                {
+                    Count = (int) imageInfo.ProcessorCount
+                },
+                Memory = new VirtualMachineMemoryConfig
+                {
+                   Startup = (int) Math.Ceiling(imageInfo.MemoryStartup / 1024d / 1024),
+                   Maximum = (int)Math.Ceiling(imageInfo.MemoryMaximum / 1024d / 1024),
+                   Minimum = (int)Math.Ceiling(imageInfo.MemoryMinimum / 1024d / 1024)
+                },
+
+                Drives = ConvertImageDrivesToConfig(imageInfo),
+                NetworkAdapters = ConvertImageNetAdaptersToConfig(imageInfo)
+            };
+
+        }
+
+        private static List<VirtualMachineDriveConfig> ConvertImageDrivesToConfig(ImageVirtualMachineInfo imageInfo)
+        {
+            var result = imageInfo.HardDrives.Select(
+                hardDiskDriveInfo => new VirtualMachineDriveConfig
+                {
+                    Name = Path.GetFileNameWithoutExtension(hardDiskDriveInfo.Path), 
+                    Size = (int) Math.Ceiling(hardDiskDriveInfo.Size / 1024d / 1024 / 1024), 
+                    Type = VirtualMachineDriveType.VHD
+                }).ToList();
+            
+            result.AddRange(imageInfo.DVDDrives.Select(dvdDriveInfo => new VirtualMachineDriveConfig
+            {
+                Type = VirtualMachineDriveType.DVD
+            }));
+
+            return result;
+        }
+
+        private static List<VirtualMachineNetworkAdapterConfig> ConvertImageNetAdaptersToConfig(ImageVirtualMachineInfo imageInfo)
+        {
+            return imageInfo.NetworkAdapters.Select(
+                adapterInfo => new VirtualMachineNetworkAdapterConfig
+                {
+                    Name = adapterInfo.Name,
+                    MacAddress = !adapterInfo.DynamicMacAddressEnabled ? adapterInfo.MacAddress: null,
+                    SwitchName = adapterInfo.SwitchName
+                }).ToList();
+
+        }
+    }
+}

--- a/src/Haipa.VmManagement/ImageVirtualMachineInfoExtensions.cs
+++ b/src/Haipa.VmManagement/ImageVirtualMachineInfoExtensions.cs
@@ -54,8 +54,7 @@ namespace Haipa.Modules.VmHostAgent
                 adapterInfo => new VirtualMachineNetworkAdapterConfig
                 {
                     Name = adapterInfo.Name,
-                    MacAddress = !adapterInfo.DynamicMacAddressEnabled ? adapterInfo.MacAddress: null,
-                    SwitchName = adapterInfo.SwitchName
+                    SwitchName = adapterInfo.SwitchName ?? "Default Switch"
                 }).ToList();
 
         }

--- a/src/Haipa.VmManagement/TypedPsObject.cs
+++ b/src/Haipa.VmManagement/TypedPsObject.cs
@@ -31,6 +31,16 @@ namespace Haipa.VmManagement
             return new TypedPsObject<T>(PsObject);
         }
 
+        public TypedPsObject<TProp> GetProperty<TProp>(Expression<Func<T, TProp>> property)
+        {
+            var paramType = property.Parameters[0].Type; // first parameter of expression
+
+            var propertyMemberInfo = paramType.GetMember((property.Body as MemberExpression)?.Member.Name)[0];
+            var propertyValue = PsObject.Properties[propertyMemberInfo.Name].Value;
+
+            return new TypedPsObject<TProp>(new PSObject(propertyValue));
+        }
+
         public Seq<TypedPsObject<TSub>> GetList<TSub>(
             Expression<Func<T, IList<TSub>>> listProperty,
             Func<TSub, bool> predicateFunc) => GetList(listProperty).Where(y => predicateFunc(y.Value));

--- a/src/Haipa.VmManagement/VirtualMachineInfoExtensions.cs
+++ b/src/Haipa.VmManagement/VirtualMachineInfoExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Haipa.VmManagement;
 using Haipa.VmManagement.Data;
 using LanguageExt;

--- a/src/Haipa.VmManagement/VirtualMachineInfoExtensions.cs
+++ b/src/Haipa.VmManagement/VirtualMachineInfoExtensions.cs
@@ -27,19 +27,21 @@ namespace Haipa.Modules.VmHostAgent
                 .MapAsync(u => vmInfo);
         }
 
-        public static Task<Either<PowershellFailure, TypedPsObject<VirtualMachineInfo>>> RecreateOrReload(this TypedPsObject<VirtualMachineInfo> vmInfo, IPowershellEngine engine)
+        public static Task<Either<PowershellFailure, TypedPsObject<T>>> RecreateOrReload<T>(this TypedPsObject<T> vmInfo, IPowershellEngine engine) 
+            where T: IVirtualMachineCoreInfo
         {
             return Prelude.Try(vmInfo.Recreate().Apply(
-                    r => Prelude.RightAsync<PowershellFailure, TypedPsObject<VirtualMachineInfo>>(r).ToEither()))
+                    r => Prelude.RightAsync<PowershellFailure, TypedPsObject<T>>(r).ToEither()))
                 .MatchAsync(
                     Fail: f => vmInfo.Reload(engine),
                     Succ: s => s);
 
         }
 
-        public static Task<Either<PowershellFailure, TypedPsObject<VirtualMachineInfo>>> Reload(this TypedPsObject<VirtualMachineInfo> vmInfo, IPowershellEngine engine)
+        public static Task<Either<PowershellFailure, TypedPsObject<T>>> Reload<T>(this TypedPsObject<T> vmInfo, IPowershellEngine engine)
+        where T: IVirtualMachineCoreInfo
         {
-            return engine.GetObjectsAsync<VirtualMachineInfo>(
+            return engine.GetObjectsAsync<T>(
                     new PsCommandBuilder().AddCommand("Get-VM").AddParameter("Id", vmInfo.Value.Id))
                 .BindAsync(r => r.HeadOrNone().ToEither(new PowershellFailure {Message = "Failed to refresh VM data"}));
 


### PR DESCRIPTION
This PR adds the core implementation to import VMs from images on the VM Agent. 
The workflows to ensure that images are present are also available in a basic stage.

Further changes:
- changed controller to exclusive saga access to prevent logic issues
- each VM contains now a metadata reference in notes. This should be used to link the VM to metadata even if it is restored or moved
- metadata of vm (provisioning settings and images) are stored currently in Agent directory. This has to be redesigned later ( see also #21 )


partially implements proposal #10 
