### PR TITLE
generate operation id from correlation id

### DIFF
--- a/src/Haipa.Messages/Commands/OperationTasks/CreateMachineCommand.cs
+++ b/src/Haipa.Messages/Commands/OperationTasks/CreateMachineCommand.cs
@@ -6,9 +6,15 @@ namespace Haipa.Messages.Commands.OperationTasks
 {
 
     [SendMessageTo(MessageRecipient.Controllers)]
-    public class CreateMachineCommand : OperationTaskCommand
+    public class CreateMachineCommand : OperationTaskCommand, IHasCorrelationId
     {
         public Guid CorrelationId { get; set; }
         public MachineConfig Config { get; set; }
+    }
+
+    public interface IHasCorrelationId
+    {
+        Guid CorrelationId { get; set; }
+
     }
 }

--- a/src/Haipa.Messages/Commands/OperationTasks/UpdateMachineCommand.cs
+++ b/src/Haipa.Messages/Commands/OperationTasks/UpdateMachineCommand.cs
@@ -5,7 +5,7 @@ using Haipa.VmConfig;
 namespace Haipa.Messages.Commands.OperationTasks
 {
     [SendMessageTo(MessageRecipient.Controllers)]
-    public class UpdateMachineCommand : OperationTaskCommand
+    public class UpdateMachineCommand : OperationTaskCommand, IHasCorrelationId
     {
         public Guid CorrelationId { get; set; }
         public Guid MachineId { get; set; }


### PR DESCRIPTION
If correlation id is supported by a command, this PR will use it as operation id. 
This will prevent the operation to be executed twice in case the client sends the command multiple times.